### PR TITLE
Simplify travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ otp_release:
   - 17.1
 before_script:
   - mix deps.get --only test
-script: mix test
 sudo: false


### PR DESCRIPTION
Don't need this `script: mix test` because using default.
